### PR TITLE
The VIP Dashboard now loads the WPCOM_VIP_Plugins_UI class on plugins…

### DIFF
--- a/vip-dashboard.php
+++ b/vip-dashboard.php
@@ -13,13 +13,20 @@ Domain Path: /languages/
 */
 
 /**
+ * Initiate the WPCOM_VIP_Plugins_UI class immediately as the WPCOM_VIP_Plugins_UI
+ * class manages it's own actions and priorities
+ *
+ * Despite it's name, the class is also responsible for loading the plugins on both
+ * frontend and backend, so it always has to be loaded and initialised
+ */
+require __DIR__ . '/plugins-ui/plugins-ui.php';
+
+/**
  * Boot the new VIP Dashboard
  *
  * @return void
  */
 function vip_dashboard_init() {
-
-	require __DIR__ . '/plugins-ui/plugins-ui.php';
 
 	// admin only
 	if ( ! is_admin() )


### PR DESCRIPTION
… loaded with priority of 10 and that class, on init, registeres an action to the same hook, plugins_loaded, at priority of 5.

This can lead to a race condition and the loading of plugins may silently fail.

This commit initiates the WPCOM_VIP_Plugins_UI class immediately as the WPCOM_VIP_Plugins_UI class manages it's own actions and priorities

Fixes #60