### PR TITLE
Removing "maintenance-mode" from the plugins UI

### DIFF
--- a/plugins-ui/class.wpcom-vip-plugins-ui.php
+++ b/plugins-ui/class.wpcom-vip-plugins-ui.php
@@ -133,6 +133,7 @@ class WPCOM_VIP_Plugins_UI {
 		$this->hidden_plugins = array(
 			'internacional', // Not ready yet (ever?)
 			'wpcom-legacy-redirector', // requires code-level changes
+			'maintenance-mode', // requires theme-level changes
 
 			// Premium
 			'new-device-notification',


### PR DESCRIPTION
The maintenance mode plugin will just not work when loaded via the plugins UI.

The `VIP_MAINTENANCE_MODE` is required to be set in the theme, but if the plugins is loaded via the UI, it will run at mu-plugins--far too early for the theme to set the necessary constant.